### PR TITLE
v5 migration

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -219,7 +219,7 @@ jobs:
           files: |
             release-assets/*
           body: |
-            # @harperdb/datadog-agent-binary ${{ github.ref_name }}
+            # @harperfast/datadog-agent-binary ${{ github.ref_name }}
 
             Pre-compiled Datadog Agent binaries for all supported platforms.
 
@@ -234,7 +234,7 @@ jobs:
             ## NPM Package
 
             ```bash
-            npm install @harperdb/datadog-agent-binary
+            npm install @harperfast/datadog-agent-binary
             ```
 
             ## Verification
@@ -307,7 +307,7 @@ jobs:
             # Check if binaries exist
             if [ -d "bin" ] && [ "$(ls -A bin)" ]; then
               npm publish --access public
-              echo "Published @harperdb/datadog-agent-binary-$platform"
+              echo "Published @harperfast/datadog-agent-binary-$platform"
             else
               echo "Skipping $platform - no binaries found"
             fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datadog Agent Binary
 
-[![Datadog Agent Binaries](https://github.com/HarperDB/datadog-agent-binary/actions/workflows/build-release.yml/badge.svg)](https://github.com/HarperDB/datadog-agent-binary/actions/workflows/build-release.yml)
+[![Datadog Agent Binaries](https://github.com/HarperFast/datadog-agent-binary/actions/workflows/build-release.yml/badge.svg)](https://github.com/HarperFast/datadog-agent-binary/actions/workflows/build-release.yml)
 
 An NPM package that provides pre-built Datadog Agent binaries.
 
@@ -9,13 +9,13 @@ Additionally this repo provides tools to build from source for Linux, Windows, a
 ## Installation
 
 ```bash
-npm install @harperdb/datadog-agent-binary
+npm install @harperfast/datadog-agent-binary
 ```
 
 Or install globally:
 
 ```bash
-npm install -g @harperdb/datadog-agent-binary
+npm install -g @harperfast/datadog-agent-binary
 ```
 
 When you install this package, it automatically downloads the appropriate pre-built Datadog Agent binary for your platform.
@@ -65,7 +65,7 @@ datadog-agent-build version
 ### Programmatic Usage
 
 ```typescript
-import { DatadogAgentBuilder, BinaryManager } from '@harperdb/datadog-agent-binary';
+import { DatadogAgentBuilder, BinaryManager } from '@harperfast/datadog-agent-binary';
 
 // Use pre-built binaries
 const manager = new BinaryManager();
@@ -145,7 +145,7 @@ interface BuildOptions {
 ### Platform Detection
 
 ```typescript
-import { detectPlatform, getAllSupportedPlatforms } from '@harperdb/datadog-agent-binary';
+import { detectPlatform, getAllSupportedPlatforms } from '@harperfast/datadog-agent-binary';
 
 const currentPlatform = detectPlatform();
 const allPlatforms = getAllSupportedPlatforms();
@@ -175,6 +175,50 @@ npm run typecheck
 # Build a single platform for testing
 npm run build-platform
 ```
+
+## Harper v5 (Lincoln) compatibility
+
+This package is compatible with Harper v5. A few notes for consumers running
+Harper v5 applications:
+
+### Spawning the agent from a Harper component
+
+Harper v5 tightens `node:child_process` semantics for code running inside an
+application. Any `spawn` / `exec` / `execFile` may only target an executable
+listed in `applications.allowedSpawnCommands`, and must include a `name`
+option so Harper can dedupe the child across worker threads.
+
+The `datadog-agent` CLI shim and the `BinaryManager`-generated wrapper
+already pass `name: "datadog-agent"`, so the only thing the consuming
+application needs to do is register the resolved binary path in
+`harperdb-config.yaml`:
+
+```yaml
+applications:
+  allowedSpawnCommands:
+    - datadog-agent
+```
+
+(Use the full resolved path returned by
+`BinaryManager.ensureBinary()` if your deployment requires an absolute
+match.)
+
+### Install scripts
+
+Harper v5 installs packages with `--ignore-scripts` by default. This package
+and its platform sub-packages **do not** rely on install scripts — the
+correct platform binary is selected automatically through
+`optionalDependencies`. You do **not** need to set
+`applications.allowInstallScripts: true` in `harperdb-config.yaml` to
+install this package.
+
+### Build-time tooling
+
+`DatadogAgentBuilder` (the source-build path that shells out to `dda`, `go`,
+`pipx`, `pip`, etc.) is intended for use from a developer shell or CI runner,
+not from inside a Harper-managed process. The runtime entry point —
+`BinaryManager.ensureBinary()` plus the `datadog-agent` wrapper — is the
+supported way to use this package from a Harper component.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -191,17 +191,26 @@ option so Harper can dedupe the child across worker threads.
 The `datadog-agent` CLI shim and the `BinaryManager`-generated wrapper
 already pass `name: "datadog-agent"`, so the only thing the consuming
 application needs to do is register the resolved binary path in
-`harperdb-config.yaml`:
+`harperdb-config.yaml`. Harper does an exact-match lookup against the
+**absolute** path passed to `spawn`, so the full path is required — a bare
+command name will not match.
+
+Resolve the path with `BinaryManager.ensureBinary()`:
+
+```js
+import { BinaryManager } from '@harperfast/datadog-agent-binary';
+const binaryPath = await new BinaryManager().ensureBinary();
+console.log(binaryPath);
+// e.g. /app/node_modules/@harperfast/datadog-agent-binary-linux-x64/bin/datadog-agent
+```
+
+Then add that exact path to `harperdb-config.yaml`:
 
 ```yaml
 applications:
   allowedSpawnCommands:
-    - datadog-agent
+    - /app/node_modules/@harperfast/datadog-agent-binary-linux-x64/bin/datadog-agent
 ```
-
-(Use the full resolved path returned by
-`BinaryManager.ensureBinary()` if your deployment requires an absolute
-match.)
 
 ### Install scripts
 

--- a/bin/datadog-agent
+++ b/bin/datadog-agent
@@ -9,9 +9,14 @@ async function main() {
 		const manager = new BinaryManager();
 		const binaryPath = await manager.ensureBinary();
 
+		// Harper v5 requires `name` on spawn options when invoked from inside a
+		// Harper application — it lets Harper dedupe the child across worker
+		// threads. The option is silently ignored by stock Node.js, so this is
+		// safe outside Harper too.
 		const child = spawn(binaryPath, process.argv.slice(2), {
 			stdio: "inherit",
 			env: process.env,
+			name: "datadog-agent",
 		});
 
 		child.on("exit", (code) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@harperdb/datadog-agent-binary",
+	"name": "@harperfast/datadog-agent-binary",
 	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@harperdb/datadog-agent-binary",
+			"name": "@harperfast/datadog-agent-binary",
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
@@ -33,11 +33,11 @@
 				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
-				"@harperdb/datadog-agent-binary-darwin-arm64": "0.0.1",
-				"@harperdb/datadog-agent-binary-darwin-x64": "0.0.1",
-				"@harperdb/datadog-agent-binary-linux-arm64": "0.0.1",
-				"@harperdb/datadog-agent-binary-linux-x64": "0.0.1",
-				"@harperdb/datadog-agent-binary-windows-x64": "0.0.1"
+				"@harperfast/datadog-agent-binary-darwin-arm64": "0.0.1",
+				"@harperfast/datadog-agent-binary-darwin-x64": "0.0.1",
+				"@harperfast/datadog-agent-binary-linux-arm64": "0.0.1",
+				"@harperfast/datadog-agent-binary-linux-x64": "0.0.1",
+				"@harperfast/datadog-agent-binary-windows-x64": "0.0.1"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -464,19 +464,6 @@
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"node_modules/@harperdb/datadog-agent-binary-linux-arm64": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@harperdb/datadog-agent-binary-linux-arm64/-/datadog-agent-binary-linux-arm64-0.0.1.tgz",
-			"integrity": "sha512-ujpX7RFbZbXdlqKMkHbS1JrBTsuzfSUiRZ0aU4xP9ZVXwM+DzsDaLgIWovWV5ZFWc4rC+hnndQ/NhNQZ02sdkQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			]
 		},
 		"node_modules/@types/node": {
 			"version": "20.19.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@harperdb/datadog-agent-binary",
+	"name": "@harperfast/datadog-agent-binary",
 	"version": "0.0.1",
 	"description": "TypeScript package to download and build Datadog Agent from source for multiple platforms",
 	"main": "dist/index.js",
@@ -59,18 +59,18 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/HarperDB/datadog-agent-binary.git"
+		"url": "git+https://github.com/HarperFast/datadog-agent-binary.git"
 	},
 	"bugs": {
-		"url": "https://github.com/HarperDB/datadog-agent-binary/issues"
+		"url": "https://github.com/HarperFast/datadog-agent-binary/issues"
 	},
-	"homepage": "https://github.com/HarperDB/datadog-agent-binary#readme",
+	"homepage": "https://github.com/HarperFast/datadog-agent-binary#readme",
 	"optionalDependencies": {
-		"@harperdb/datadog-agent-binary-linux-x64": "0.0.1",
-		"@harperdb/datadog-agent-binary-linux-arm64": "0.0.1",
-		"@harperdb/datadog-agent-binary-darwin-x64": "0.0.1",
-		"@harperdb/datadog-agent-binary-darwin-arm64": "0.0.1",
-		"@harperdb/datadog-agent-binary-windows-x64": "0.0.1"
+		"@harperfast/datadog-agent-binary-linux-x64": "0.0.1",
+		"@harperfast/datadog-agent-binary-linux-arm64": "0.0.1",
+		"@harperfast/datadog-agent-binary-darwin-x64": "0.0.1",
+		"@harperfast/datadog-agent-binary-darwin-arm64": "0.0.1",
+		"@harperfast/datadog-agent-binary-windows-x64": "0.0.1"
 	},
 	"lint-staged": {
 		"*.{ts,js,json}": [

--- a/scripts/create-platform-packages.js
+++ b/scripts/create-platform-packages.js
@@ -72,10 +72,10 @@ const packageTemplate = {
 	main: "index.js",
 	repository: {
 		type: "git",
-		url: "https://github.com/HarperDB/datadog-agent-binary.git",
+		url: "https://github.com/HarperFast/datadog-agent-binary.git",
 	},
 	keywords: ["datadog", "agent", "binary"],
-	author: "HarperDB",
+	author: "Harper",
 	license: "Apache-2.0",
 	files: ["bin/", "index.js"],
 };
@@ -93,7 +93,7 @@ function writePlatformPackageJson(platform) {
 	const arch = platform.getArch();
 	const packageJson = {
 		...packageTemplate,
-		name: `@harperdb/datadog-agent-binary-${platform.getName()}`,
+		name: `@harperfast/datadog-agent-binary-${platform.getName()}`,
 		description: `Datadog Agent binary for ${os} ${arch}`,
 		os: [os],
 		cpu: [arch],

--- a/scripts/update-optional-deps.js
+++ b/scripts/update-optional-deps.js
@@ -13,7 +13,7 @@ const platforms = getAllSupportedPlatforms();
 packageJson.optionalDependencies = {};
 platforms.forEach((platform) => {
 	packageJson.optionalDependencies[
-		`@harperdb/datadog-agent-binary-${platform}`
+		`@harperfast/datadog-agent-binary-${platform}`
 	] = packageJson.version;
 });
 

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -98,9 +98,14 @@ async function main() {
     const manager = new BinaryManager();
     const binaryPath = await manager.ensureBinary();
 
+    // Harper v5 requires \`name\` on spawn options when invoked from inside a
+    // Harper application — it lets Harper dedupe the child across worker
+    // threads. The option is silently ignored by stock Node.js, so this is
+    // safe outside Harper too.
     const child = spawn(binaryPath, process.argv.slice(2), {
       stdio: 'inherit',
-      env: process.env
+      env: process.env,
+      name: 'datadog-agent'
     });
 
     child.on('exit', (code) => {
@@ -118,8 +123,13 @@ main();
 	}
 
 	private createWindowsWrapper(): string {
+		// The original cmd wrapper invoked `dist/binary-manager.js` directly,
+		// but that file is a module — it has no top-level main and never
+		// spawned the agent. Delegate to the same Node wrapper logic used on
+		// Unix so the agent binary is actually launched (with the v5-required
+		// `name` option).
 		return `@echo off
-node "%~dp0\\..\\dist\\binary-manager.js" %*
+node -e "(async()=>{const{BinaryManager}=require('%~dp0\\..\\dist\\binary-manager.js');const{spawn}=require('child_process');try{const m=new BinaryManager();const b=await m.ensureBinary();const c=spawn(b,process.argv.slice(1),{stdio:'inherit',env:process.env,name:'datadog-agent'});c.on('exit',code=>process.exit(code||0));}catch(e){console.error('Failed to run datadog-agent:',e.message);process.exit(1);}})()" %*
 `;
 	}
 

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -129,7 +129,7 @@ main();
 		// Unix so the agent binary is actually launched (with the v5-required
 		// `name` option).
 		//
-		// Two Windows-specific gotchas the implementation works around:
+		// Three Windows-specific gotchas the implementation works around:
 		//   1. Inlining %~dp0 into the JS string literal corrupts the path —
 		//      backslashes get interpreted as JS escapes (\U, \b, ...). Pass
 		//      the path through argv instead so it stays a literal string.
@@ -137,9 +137,11 @@ main();
 		//      "...\foo\" — the MS argv parser treats \" as a literal quote
 		//      and the next user arg bleeds in. Appending a dot ("%~dp0.")
 		//      makes the trailing char `.`, which path.join normalizes away.
-		//   3. With `node -e "<code>" "<path>" <args...>`, argv is
+		//   3. With `node -e "<code>" "<path>" <args...>`, there is no script
+		//      slot in argv — the path lands at argv[1] and user args start at
+		//      argv[2] (unlike `node script.js` where argv[1] is the script).
 		return `@echo off
-node -e "const path=require('path');const{BinaryManager}=require(path.join(process.argv[2],'..','dist','binary-manager.js'));const{spawn}=require('child_process');(async()=>{try{const m=new BinaryManager();const b=await m.ensureBinary();const c=spawn(b,process.argv.slice(3),{stdio:'inherit',env:process.env,name:'datadog-agent'});c.on('exit',code=>process.exit(code||0));}catch(e){console.error('Failed to run datadog-agent:',e.message);process.exit(1);}})()" "%~dp0" %*
+node -e "const path=require('path');const{spawn}=require('child_process');(async()=>{try{const{BinaryManager}=require(path.join(process.argv[1],'..','dist','binary-manager.js'));const m=new BinaryManager();const b=await m.ensureBinary();const c=spawn(b,process.argv.slice(2),{stdio:'inherit',env:process.env,name:'datadog-agent'});c.on('exit',code=>process.exit(code||0));}catch(e){console.error('Failed to run datadog-agent:',e.message);process.exit(1);}})()" "%~dp0." %*
 `;
 	}
 

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -128,8 +128,19 @@ main();
 		// spawned the agent. Delegate to the same Node wrapper logic used on
 		// Unix so the agent binary is actually launched (with the v5-required
 		// `name` option).
+		//
+		// Two Windows-specific gotchas the implementation works around:
+		//   1. Inlining %~dp0 into the JS string literal corrupts the path —
+		//      backslashes get interpreted as JS escapes (\U, \b, ...). Pass
+		//      the path through argv instead so it stays a literal string.
+		//   2. %~dp0 always has a trailing backslash, so "%~dp0" becomes
+		//      "...\foo\" — the MS argv parser treats \" as a literal quote
+		//      and the next user arg bleeds in. Appending a dot ("%~dp0.")
+		//      makes the trailing char `.`, which path.join normalizes away.
+		//   3. With `node -e "<code>" "<path>" <args...>`, argv is
+		//      [node, '[eval]', path, ...userArgs], so slice past index 3.
 		return `@echo off
-node -e "(async()=>{const{BinaryManager}=require('%~dp0\\..\\dist\\binary-manager.js');const{spawn}=require('child_process');try{const m=new BinaryManager();const b=await m.ensureBinary();const c=spawn(b,process.argv.slice(1),{stdio:'inherit',env:process.env,name:'datadog-agent'});c.on('exit',code=>process.exit(code||0));}catch(e){console.error('Failed to run datadog-agent:',e.message);process.exit(1);}})()" %*
+node -e "const path=require('path');const{BinaryManager}=require(path.join(process.argv[2],'..','dist','binary-manager.js'));const{spawn}=require('child_process');(async()=>{try{const m=new BinaryManager();const b=await m.ensureBinary();const c=spawn(b,process.argv.slice(3),{stdio:'inherit',env:process.env,name:'datadog-agent'});c.on('exit',code=>process.exit(code||0));}catch(e){console.error('Failed to run datadog-agent:',e.message);process.exit(1);}})()" "%~dp0." %*
 `;
 	}
 

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -138,9 +138,8 @@ main();
 		//      and the next user arg bleeds in. Appending a dot ("%~dp0.")
 		//      makes the trailing char `.`, which path.join normalizes away.
 		//   3. With `node -e "<code>" "<path>" <args...>`, argv is
-		//      [node, '[eval]', path, ...userArgs], so slice past index 3.
 		return `@echo off
-node -e "const path=require('path');const{BinaryManager}=require(path.join(process.argv[2],'..','dist','binary-manager.js'));const{spawn}=require('child_process');(async()=>{try{const m=new BinaryManager();const b=await m.ensureBinary();const c=spawn(b,process.argv.slice(3),{stdio:'inherit',env:process.env,name:'datadog-agent'});c.on('exit',code=>process.exit(code||0));}catch(e){console.error('Failed to run datadog-agent:',e.message);process.exit(1);}})()" "%~dp0." %*
+node -e "const path=require('path');const{BinaryManager}=require(path.join(process.argv[2],'..','dist','binary-manager.js'));const{spawn}=require('child_process');(async()=>{try{const m=new BinaryManager();const b=await m.ensureBinary();const c=spawn(b,process.argv.slice(3),{stdio:'inherit',env:process.env,name:'datadog-agent'});c.on('exit',code=>process.exit(code||0));}catch(e){console.error('Failed to run datadog-agent:',e.message);process.exit(1);}})()" "%~dp0" %*
 `;
 	}
 

--- a/src/builders/base.ts
+++ b/src/builders/base.ts
@@ -77,11 +77,17 @@ export abstract class BaseBuilder {
 	): Promise<string> {
 		return new Promise((resolve, reject) => {
 			const [cmd, ...args] = command.split(" ");
+			// Harper v5 requires `name` on spawn options when invoked from
+			// inside a Harper application. The builder is normally run from a
+			// dev shell or CI, but adding `name` keeps the call valid if the
+			// builder API is ever invoked from a Harper-managed process. The
+			// option is silently ignored by stock Node.js.
 			const child = spawn(cmd, args, {
 				cwd,
 				env,
 				stdio: ["inherit", "pipe", "pipe"],
-			});
+				name: `datadog-agent-builder:${cmd}`,
+			} as any);
 
 			let stdout = "";
 			let stderr = "";

--- a/src/builders/base.ts
+++ b/src/builders/base.ts
@@ -77,11 +77,13 @@ export abstract class BaseBuilder {
 	): Promise<string> {
 		return new Promise((resolve, reject) => {
 			const [cmd, ...args] = command.split(" ");
-			// Harper v5 requires `name` on spawn options when invoked from
-			// inside a Harper application. The builder is normally run from a
-			// dev shell or CI, but adding `name` keeps the call valid if the
-			// builder API is ever invoked from a Harper-managed process. The
-			// option is silently ignored by stock Node.js.
+			// `name` is set here purely for consistency with the runtime
+			// spawn in `bin/datadog-agent` and the BinaryManager-generated
+			// wrapper. The builder itself is dev/CI-only — it also calls
+			// `execSync` elsewhere in this file, which Harper v5 forbids
+			// outright, so the builder can never run inside a Harper-managed
+			// process regardless of this option. Stock Node.js ignores
+			// `name`, so there is no effect outside Harper either.
 			const child = spawn(cmd, args, {
 				cwd,
 				env,


### PR DESCRIPTION
Updates this package for the v5 (Lincoln) release per the [v5 migration guide](https://docs.harperdb.io/release-notes/v5-lincoln/v5-migration).
Rebrand: @harperdb → @harperfast, HarperDB → HarperFast

Package renamed to @harperfast/datadog-agent-binary; all five platform sub-packages in optionalDependencies renamed to match.
Platform-package generator (scripts/create-platform-packages.js) and version sync script (scripts/update-optional-deps.js) updated to emit @harperfast/... names; author changed HarperDB → Harper.
GitHub URLs updated to github.com/HarperFast/datadog-agent-binary in package.json, scripts/create-platform-packages.js, and the README badge.
Release workflow user-facing strings (release notes header, install snippet, publish log line) updated.

child_process.spawn compliance
v5 requires a name option on every spawn/exec from inside a Harper app so the runtime can dedupe the child across worker threads.

bin/datadog-agent: added name: "datadog-agent".
src/binary-manager.ts: same option added to the Unix wrapper template. Also fixed the Windows wrapper, which previously shelled out to dist/binary-manager.js (a module with no main — it never actually spawned the agent); it now uses the same Node spawn logic as the Unix wrapper with the name option.
src/builders/base.ts: added name: \datadog-agent-builder:${cmd}`` to the long-running build spawn for consistency.